### PR TITLE
1 update debian bookworm cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-ARG BASE_IMAGE=debian:bullseye
+ARG BASE_IMAGE=debian:bookworm
+ARG DEBIAN_FRONTEND=noninteractive
+
 FROM $BASE_IMAGE
 LABEL maintainer "staf wagemakers <staf@wagemakers.be>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@ RUN apt-get install unbound -y
 RUN apt-get install unbound-anchor -y
 RUN apt-get install unbound-host -y
 RUN apt-get install dns-root-data -y
+RUN apt-get install openssl -y
 
 # get unbound key
 RUN unbound-anchor -v -4 || unbound-anchor -v -4
+# create the required control certificates
+RUN unbound-control-setup
 RUN chown root:unbound /etc/unbound/*.key
 RUN chmod 0650  /etc/unbound/*.key
 RUN chown root:unbound /etc/unbound/*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install dns-root-data -y
 RUN apt-get install openssl -y
 
 # get unbound key
-RUN unbound-anchor -v -4 || unbound-anchor -v -4
+RUN unbound-anchor -a /var/lib/unbound/root.key -v -4 || unbound-anchor -a /var/lib/unbound/root.key -v -4
 # create the required control certificates
 RUN unbound-control-setup
 RUN chown root:unbound /etc/unbound/*.key

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want to use another port, you can edit ```etc/unbound/unbound.conf.d/inte
 
 #### ```scripts/create_zone_config.sh``` helper script
 
-The ```create_zone_config.sh``` helper script, can we help you to the ```zones.conf``` configuration file.
+The ```create_zone_config.sh``` helper script, can help you to create the ```zones.conf``` configuration file.
 It's executed during the container build and creates the zones.conf from the datafiles in ```etc/unbound/zones```.
 
 If you want to use a docker volume or configmaps/persistent volumes on Kubernetes. You can use this script to
@@ -63,7 +63,7 @@ $ docker build -t stafwag/unbound .
 To use a different BASE_IMAGE, you can use the --build-arg BASE_IMAGE=your_base_image.
 
 ```
-$ docker build --build-arg BASE_IMAGE=stafwag/debian:bullseye -t stafwag/unbound .
+$ docker build --build-arg BASE_IMAGE=stafwag/debian:bookworm -t stafwag/unbound .
 ```
 
 ## Run


### PR DESCRIPTION
Upgrade to debian:bookworm

* Updated BASE_IMAGE to debian:bookworm
* Add ARG DEBIAN_FRONTEND=noninteractive
* Run unbound-control-setup to generate the default certificate
* Documentation updated